### PR TITLE
Organize SCC expansion module

### DIFF
--- a/balm/interaction_graph_utils.py
+++ b/balm/interaction_graph_utils.py
@@ -148,3 +148,30 @@ def cleanup_network(network: BooleanNetwork) -> BooleanNetwork:
         )
 
     return network.infer_valid_graph()
+
+
+def source_SCCs(bn: BooleanNetwork) -> list[list[str]]:
+    """
+    Find source SCCs of the given `BooleanNetwork`.
+
+    Here, SCC stands for "strongly connected component". An SCC is a source SCC
+    if it has no incoming edges.
+
+    Parameters
+    ----------
+    bn : BooleanNetwork
+        The Boolean network to be examined.
+
+    Returns
+    -------
+    list[list[str]]
+        The list of source SCCs.
+    """
+    result: list[list[str]] = []
+    for scc in bn.strongly_connected_components():
+        scc_list = sorted(scc)
+        if bn.backward_reachable(scc_list) == scc:
+            scc_names = [bn.get_variable_name(var) for var in scc_list]
+            result.append(scc_names)
+
+    return sorted(result)

--- a/balm/space_utils.py
+++ b/balm/space_utils.py
@@ -288,6 +288,7 @@ def percolate_network(
     bn: BooleanNetwork,
     space: BooleanSpace,
     symbolic_network: AsynchronousGraph | None = None,
+    remove_constants: bool = False,
 ) -> BooleanNetwork:
     """
     Reduces a Boolean network by percolating a given space.
@@ -315,6 +316,9 @@ def percolate_network(
     symbolic_network : AsynchronousGraph | None
         An optional symbolic representation to use to perform the percolation. If not
         given, a temporary one will be created from `bn`.
+    remove_constants : bool
+        If `True`, then the constants are removed from the resulting network. By
+        default, `False`.
 
     Returns
     -------
@@ -349,7 +353,11 @@ def percolate_network(
             new_update = UpdateFunction(new_bn, percolated)
             new_bn.set_update_function(var, new_update)
 
-    return new_bn.infer_valid_graph()
+    new_bn = new_bn.infer_valid_graph()
+    if remove_constants:
+        new_bn = new_bn.inline_constants(infer_constants=True, repair_graph=True)
+
+    return new_bn
 
 
 def restrict_expression(

--- a/tests/source_SCC_test.py
+++ b/tests/source_SCC_test.py
@@ -5,7 +5,6 @@ from balm._sd_algorithms.expand_source_SCCs import (
     expand_source_SCCs,
     find_source_nodes,
     find_subnetwork_sd,
-    perc_and_remove_constants_from_bn,
 )
 from balm.space_utils import percolate_network, percolate_space
 
@@ -49,7 +48,7 @@ def test_perc_and_remove_constants_from_bn():
     after_perc_0, after_perc_0 & constant1_0"""
     ).infer_valid_graph()
 
-    clean_bnet = perc_and_remove_constants_from_bn(bn, {}).to_bnet()
+    clean_bnet = percolate_network(bn, {}, remove_constants=True).to_bnet()
 
     bn2 = BooleanNetwork.from_bnet(
         """targets,factors
@@ -58,7 +57,7 @@ def test_perc_and_remove_constants_from_bn():
     source_after_perc, source_after_perc"""
     )
 
-    clean_bnet2 = perc_and_remove_constants_from_bn(bn2, {}).to_bnet()
+    clean_bnet2 = percolate_network(bn2, {}, remove_constants=True).to_bnet()
 
     assert clean_bnet == clean_bnet2
 
@@ -71,10 +70,10 @@ B, A | C"""
     )
 
     # This "simulates" what would happen in the SCC expansion algorithm.
-    bn = perc_and_remove_constants_from_bn(bn, {"C": 0})
+    bn = percolate_network(bn, {"C": 0}, remove_constants=True)
 
     scc_sd, _ = find_subnetwork_sd(
-        bn,
+        SuccessionDiagram(bn),
         expander=SuccessionDiagram.expand_bfs,
         check_maa=True,
     )


### PR DESCRIPTION
@daemontus I forgot that I had never made a PR for this branch. We'll need to do some more work to make the expansion methods intuitive for the end-user still, but I think this is a necessary first step.

Moves some of the source scc logic to the `SuccessionDiagram` class (adds `component_subdiagrams` method) and to the `interaction_graph_utils` module (adds `source_SCCs` function). This finally gives a proper resolution to our cyclic import issues.

Also, functionality from the custom percolation function in `expand_source_SCCs.py` was integrated into `space_utils.percolate_network` as an option.